### PR TITLE
Answer length increases to 2-3 sentence

### DIFF
--- a/app/modules/llm/service.py
+++ b/app/modules/llm/service.py
@@ -204,7 +204,7 @@ def get_qa_prompt():
                     "Your role is to assist customers calling the company by giving clear, polite, and accurate spoken-style answers.\n"
                     "Use ONLY the provided context to answer the question.\n"
                     "If the answer is not found in the context, say politely that you don't have that information.\n"
-                    "Keep responses ultra-short, natural, and conversational (one sentence, under 20 words).\n"
+                    "Keep responses helpful, natural, and conversational (2-3 sentences, roughly 40-60 words).\n"
                     "Do NOT make up information. Do NOT reference 'documents' or 'context' explicitly."
                 ),
             ),

--- a/app/modules/pipeline/pipeline.py
+++ b/app/modules/pipeline/pipeline.py
@@ -357,8 +357,8 @@ def node_answer(state: RAGState):
     search_type = "similarity_search"
     use_reranker = False
     
-    # Use k=2 for small, fast context
-    k = 2
+    # Use k=4 for a more detailed context while still remaining fast
+    k = 4
     
     logger.debug(f"STEP 6: Performing {search_type}, use_reranker={use_reranker}, k={k}")
 


### PR DESCRIPTION
1. The "Instructions" (System Prompt)
File: app/modules/llm/service.py

The Change: I updated the AI's core instructions (system prompt).
Old Code: "Keep responses ultra-short... (one sentence, under 20 words)"
New Code: "Keep responses helpful... (2-3 sentences, roughly 40-60 words)"
Why?: The AI follows these instructions strictly. Previously, even if it had a lot of useful information, it would "delete" most of it to follow the "one sentence" rule. Now, it has the freedom to be more detailed and natural.

2. The "Knowledge Access" (Retrieval k-value)
File: app/modules/pipeline/pipeline.py

The Change: I increased the value of k from 2 to 4.
Old Code: k = 2
New Code: k = 4
Why?: k is the number of documents the bot "reads" from your database before it starts talking.
With k=2: The bot was only seeing a tiny snippet of your data, so it didn't have much to say.
With k=4: The bot now sees twice as much information (4 chunks of your documents), which allows it to provide more context about "tracking," "logistics partners," or "remote assistance" as we saw in the tests.